### PR TITLE
Fix V3021

### DIFF
--- a/Stack/Core/Types/BuiltIn/DataValue.cs
+++ b/Stack/Core/Types/BuiltIn/DataValue.cs
@@ -245,11 +245,6 @@ namespace Opc.Ua
                     return false;
                 }
 
-                if (this.m_serverTimestamp != value.m_serverTimestamp)
-                {
-                    return false;
-                }
-
                 return Utils.IsEqual(this.m_value.Value, value.m_value.Value);
             }
             


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- There are two 'if' statements with identical conditional expressions. The first 'if' statement contains method return. This means that the second 'if' statement is senseless UA Core Library DataValue.cs 233