### PR TITLE
Fix V3025

### DIFF
--- a/Stack/Core/Security/Certificates/CertificateFactory.cs
+++ b/Stack/Core/Security/Certificates/CertificateFactory.cs
@@ -562,7 +562,7 @@ namespace Opc.Ua
             {
                 StreamWriter writer = new StreamWriter(tempFile);
 
-                writer.WriteLine("-cmd issue", storePath);
+                writer.WriteLine("-cmd issue {0}", storePath);
 
                 if (!String.IsNullOrEmpty(storePath))
                 {
@@ -751,7 +751,7 @@ namespace Opc.Ua
                 // write the arguments to a temp file.
                 StreamWriter writer = new StreamWriter(tempFile);
 
-                writer.WriteLine("-cmd revoke", storePath);
+                writer.WriteLine("-cmd revoke {0}", storePath);
 
                 if (!String.IsNullOrEmpty(storePath))
                 {


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Arguments not used: storePath. UA Core Library CertificateFactory.cs 565

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Arguments not used: storePath. UA Core Library CertificateFactory.cs 754