### PR TITLE
Fix V3029

### DIFF
--- a/Stack/Core/Stack/State/NodeState.cs
+++ b/Stack/Core/Stack/State/NodeState.cs
@@ -791,7 +791,7 @@ namespace Opc.Ua
                 attributesToSave |= AttributesToSave.WriteMask;
             }
 
-            if (m_writeMask != AttributeWriteMask.None)
+            if (m_userWriteMask != AttributeWriteMask.None)
             {
                 attributesToSave |= AttributesToSave.UserAccessLevel;
             }
@@ -1291,7 +1291,7 @@ namespace Opc.Ua
                 encoder.WriteEnumerated("WriteMask", m_writeMask);
             }
 
-            if (m_writeMask != AttributeWriteMask.None)
+            if (m_userWriteMask != AttributeWriteMask.None)
             {
                 encoder.WriteEnumerated("UserWriteMask", m_userWriteMask);
             }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The conditional expressions of the 'if' statements situated alongside each other are identical. Check lines: 789, 794. UA Core Library NodeState.cs 789

- The conditional expressions of the 'if' statements situated alongside each other are identical. Check lines: 1289, 1294. UA Core Library NodeState.cs 1289