### PR TITLE
Fix V3029

### DIFF
--- a/Stack/Core/Types/Utils/TypeInfo.cs
+++ b/Stack/Core/Types/Utils/TypeInfo.cs
@@ -598,20 +598,6 @@ namespace Opc.Ua
                 }
             }
             
-            // A ByteString is equivalent to an Array of Bytes.
-            if (typeInfo.BuiltInType == BuiltInType.ByteString && typeInfo.ValueRank == ValueRanks.Scalar)
-            {
-                if (expectedValueRank == ValueRanks.OneOrMoreDimensions || expectedValueRank == ValueRanks.OneDimension)
-                {
-                    if (typeTree.IsTypeOf(expectedDataTypeId, DataTypes.Byte))
-                    {
-                        return typeInfo;
-                    }
-
-                    return null;
-                }
-            }
-
             // check the value rank.
             if (!ValueRanks.IsValid(typeInfo.ValueRank, expectedValueRank))
             {


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The conditional expressions of the 'if' statements situated alongside each other are identical. Check lines: 588, 602. UA Core Library TypeInfo.cs 588