### PR TITLE
Fix V3030

### DIFF
--- a/Stack/Core/Stack/State/AlarmConditionState.cs
+++ b/Stack/Core/Stack/State/AlarmConditionState.cs
@@ -348,18 +348,12 @@ namespace Opc.Ua
 
             if (!this.ConfirmedState.Id.Value)
             {
-                if (!this.ConfirmedState.Id.Value)
-                {
-                    ackState = this.ConfirmedState.Value;
-                }
+                ackState = this.ConfirmedState.Value;
             }
 
             if (!this.AckedState.Id.Value)
             {
-                if (!this.AckedState.Id.Value)
-                {
-                    ackState = this.AckedState.Value;
-                }
+               ackState = this.AckedState.Value;
             }
 
             if (ackState != null)


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Recurring check. The '!this.ConfirmedState.Id.Value' condition was already verified in line 349. UA Core Library AlarmConditionState.cs 351

- Recurring check. The '!this.AckedState.Id.Value' condition was already verified in line 357. UA Core Library AlarmConditionState.cs 359