### PR TITLE
Update for server nonce validation

### DIFF
--- a/SampleApplications/SampleLibraries/Client/Session.cs
+++ b/SampleApplications/SampleLibraries/Client/Session.cs
@@ -3318,20 +3318,18 @@ namespace Opc.Ua.Client
         /// </summary>
         private void ValidateServerNonce(IUserIdentity identity, byte[] serverNonce, string securityPolicyUri)
         {
+            // skip validation if server nonce is not used for encryption.
+            if (String.IsNullOrEmpty(securityPolicyUri) || securityPolicyUri == SecurityPolicies.None)
+            {
+                return;
+            }
+
             if (identity != null && identity.TokenType != UserTokenType.Anonymous)
             {
                 // the server nonce should be validated if the token includes a secret.
-                if (!Utils.Nonce.ValidateNonce(serverNonce, MessageSecurityMode.SignAndEncrypt, securityPolicyUri))
+                if (!Utils.Nonce.ValidateNonce(serverNonce, MessageSecurityMode.SignAndEncrypt, m_configuration.SecurityConfiguration.NonceLength))
                 {
                     throw ServiceResultException.Create(StatusCodes.BadNonceInvalid, "Server nonce is not the correct length or not random enough.");
-                }
-
-                // token encryption is mandatory over a channel without security if it includes a secret.
-                if (m_endpoint != null && m_endpoint.Description != null &&
-                    m_endpoint.Description.SecurityPolicyUri == SecurityPolicies.None &&
-                    securityPolicyUri == SecurityPolicies.None)
-                {
-                    throw ServiceResultException.Create(StatusCodes.BadSecurityModeInsufficient, "User identity cannot be sent over the current secure channel without encryption.");
                 }
             }
         }

--- a/Stack/Core/Types/Utils/Utils.cs
+++ b/Stack/Core/Types/Utils/Utils.cs
@@ -2364,6 +2364,14 @@ namespace Opc.Ua
             /// </summary>
             public static bool ValidateNonce(byte[] nonce, MessageSecurityMode securityMode, string securityPolicyUri)
             {
+                return ValidateNonce(nonce, securityMode, GetNonceLength(securityPolicyUri));
+            }
+
+            /// <summary>
+            /// Validates the nonce for a message security mode and a minimum length.
+            /// </summary>
+            public static bool ValidateNonce(byte[] nonce, MessageSecurityMode securityMode, int minNonceLength)
+            {
                 // no nonce needed for no security.
                 if (securityMode == MessageSecurityMode.None)
                 {
@@ -2371,7 +2379,7 @@ namespace Opc.Ua
                 }
 
                 // check the length.
-                if (nonce == null || nonce.Length < GetNonceLength(securityPolicyUri))
+                if (nonce == null || nonce.Length < minNonceLength)
                 {
                     return false;
                 }


### PR DESCRIPTION
Skip server nonce validation in ClientSession if the nonce is not used for encryption.